### PR TITLE
Add templated stream labels support for Loki sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,8 +547,20 @@ receivers:
       headers: # optional
         X-Scope-OrgID: tennantID
       streamLabels:
-        foo: bar
+        app: kubernetes-event-exporter
+        environment: production
+        reason: "{{ .Reason }}"  # templated value using event data
+        namespace: "{{ .Namespace }}"  # templated value using event data
       url: http://127.0.0.1:3100/loki/api/v1/push
       username: # optional, for basic authentication
       password: # optional, for basic authentication
+      layout: # optional, for formatting event data
+        message: "{{ .Message }}"
+        reason: "{{ .Reason }}"
+        type: "{{ .Type }}"
+        count: "{{ .Count }}"
+        kind: "{{ .InvolvedObject.Kind }}"
+        name: "{{ .InvolvedObject.Name }}"
 ```
+
+Stream labels can contain either static values (like `app: kubernetes-event-exporter`) or template values (like `reason: "{{ .Reason }}"`). Templates are only applied to values that use the `{{ ... }}` syntax, allowing you to mix static and dynamic values in your labels.


### PR DESCRIPTION
## Description
This PR adds support for using Go templates in Loki stream labels. Now you can have a mix of static values and dynamic values derived from the event data in your stream labels.

## Changes
- Add support for using Go templates in Loki stream labels
- Only apply templating to values that use  syntax
- Allow mixing static and dynamic values in stream labels
- Update documentation with examples and explanation

## Example


## Testing
- Tested with both static and templated stream label values
- Verified that only values with template syntax are processed